### PR TITLE
Update .verb.md

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -13,7 +13,7 @@ var isDescriptor = require('{%= name %}');
 isDescriptor({value: 'foo'})
 //=> true
 isDescriptor({get: function(){}, set: function(){}})
-//=> false
+//=> true
 isDescriptor({get: 'foo', set: function(){}})
 //=> false
 ```


### PR DESCRIPTION
`get` and `set` should be valid if they are both functions. I updated the output based on the input, but if you wanted to show an example like before, then I guess the input would be `isDescriptor({get: function(){}, set: 'foo')` and the output would be `false`